### PR TITLE
Feature/indicator dilution needles ratio 206

### DIFF
--- a/source-data.json
+++ b/source-data.json
@@ -363,6 +363,16 @@
             "denominatorDescription": "Total doses used",
             "denominator": "#{${dataElements['vaccine-doses-used']}}"
         },
+        "dilution-needles-ratio": {
+            "$dataElementsRequired": ["needles", "vaccine-doses-used"],
+            "name": "Dilution needles ratio",
+            "code": "RVC_CAMPAIGN_NEEDLES_RATIO",
+            "$indicatorType": "ratio",
+            "numeratorDescription": "Needles for dilution",
+            "numerator": "#{${dataElements['needles']}}",
+            "denominatorDescription": "Vaccine doses used",
+            "denominator": "#{${dataElements['vaccine-doses-used']}}"
+        },
         "vaccine-utilization-rate": {
             "$dataElementsRequired": ["vaccine-doses-administered", "vaccine-doses-used"],
             "name": "Vaccine utilization rate",

--- a/source-data.json
+++ b/source-data.json
@@ -357,7 +357,7 @@
             "$dataElementsRequired": ["syringes", "vaccine-doses-used"],
             "name": "Dilution syringes ratio",
             "code": "RVC_DILUTION_SYRINGES_RATIO",
-            "$indicatorType": "percentage",
+            "$indicatorType": "ratio",
             "numeratorDescription": "Syringes for dilution",
             "numerator": "#{${dataElements['syringes']}}",
             "denominatorDescription": "Total doses used",


### PR DESCRIPTION
Required by https://github.com/EyeSeeTea/vaccination-app/issues/206

- Name: `Dilution needles ratio`
- Value: `#{${dataElements['needles']}} / ${dataElements['vaccine-doses-used']}`
- Type: `ratio` (factor: 1)

Also, I noticed that the similar indicator "Dilution syringes ratio" was using percentage type, I changed it to ratio [*CONFIRM before merging* -> **CONFIRMED**]