### PR TITLE
Set default catCombo for population by age: antigen/dose/ageGroup

### DIFF
--- a/source-data.json
+++ b/source-data.json
@@ -253,7 +253,7 @@
             "code": "RVC_POPULATION_BY_AGE",
             "valueType": "INTEGER_ZERO_OR_POSITIVE",
             "aggregationType": "LAST",
-            "$categoryCombo": "antigen-age-group",
+            "$categoryCombo": "antigen-dose-age-group",
             "aggregationLevels": []
         },
 


### PR DESCRIPTION
Required by https://github.com/EyeSeeTea/vaccination-app/pull/220

![image](https://user-images.githubusercontent.com/24643/60578854-3dd21c00-9d82-11e9-9cb8-67124e0ef32b.png)
