### PR TITLE
Ratio by 10 on needles/syringes ratios

### DIFF
--- a/source-data.json
+++ b/source-data.json
@@ -362,7 +362,7 @@
             "numeratorDescription": "Syringes for dilution",
             "numerator": "#{${dataElements['syringes']}}",
             "denominatorDescription": "Total doses used",
-            "denominator": "#{${dataElements['vaccine-doses-used']}}"
+            "denominator": "#{${dataElements['vaccine-doses-used']}} / 10"
         },
         "dilution-needles-ratio": {
             "$dataElementsRequired": ["needles", "vaccine-doses-used"],
@@ -372,7 +372,7 @@
             "numeratorDescription": "Needles for dilution",
             "numerator": "#{${dataElements['needles']}}",
             "denominatorDescription": "Vaccine doses used",
-            "denominator": "#{${dataElements['vaccine-doses-used']}}"
+            "denominator": "#{${dataElements['vaccine-doses-used']}} / 10"
         },
         "vaccine-utilization-rate": {
             "$dataElementsRequired": ["vaccine-doses-administered", "vaccine-doses-used"],


### PR DESCRIPTION
Use ratio by 10 (_denominator / 10_) for both dilution indicators.