### PR TITLE
Use AVERAGE_SUM_ORG_UNIT for population by age

### DIFF
--- a/source-data.json
+++ b/source-data.json
@@ -413,7 +413,7 @@
             "code": "RVC_POPULATION_BY_AGE",
             "valueType": "NUMBER",
             "zeroIsSignificant": true,
-            "aggregationType": "LAST",
+            "aggregationType": "AVERAGE_SUM_ORG_UNIT",
             "$categoryCombo": "antigen-dose-age-group",
             "aggregationLevels": []
         },

--- a/source-data.json
+++ b/source-data.json
@@ -380,6 +380,10 @@
         "all": {
             "name": "RVC - All Data Elements",
             "code": "RVC_ANTIGEN"
+        },
+        "population": {
+            "name": "RVC - Population",
+            "code": "RVC_POPULATION"
         }
     },
 
@@ -397,6 +401,7 @@
             "aggregationType": "LAST",
             "valueType": "INTEGER_ZERO_OR_POSITIVE",
             "zeroIsSignificant": true,
+            "$type": "population",
             "aggregationLevels": [1, 2, 3, 4, 5, 6]
         },
         "age-distribution": {
@@ -406,6 +411,7 @@
             "code": "RVC_AGE_DISTRIBUTION",
             "aggregationType": "LAST",
             "$categoryCombo": "age-group",
+            "$type": "population",
             "aggregationLevels": [1, 2, 3, 4, 5, 6]
         },
         "population-by-age": {
@@ -415,6 +421,7 @@
             "zeroIsSignificant": true,
             "aggregationType": "AVERAGE_SUM_ORG_UNIT",
             "$categoryCombo": "antigen-dose-age-group",
+            "$type": "population",
             "aggregationLevels": []
         },
 

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -310,6 +310,7 @@ function getDataElementsMetadata(db, sourceData, categoriesMetadata) {
             return { dataElements, categoryCombos: categoryCombosForDataElements };
         })
     );
+
     const dataElementGroupsMetadata = flattenPayloads(
         toKeyList(sourceData, "antigens").map(antigen => {
             const dataElementGroupsForAntigen = getDataElementGroupsForAntigen(
@@ -338,10 +339,19 @@ function getDataElementsMetadata(db, sourceData, categoriesMetadata) {
         dataElements: getIds(dataElementsMetadata.dataElements),
     });
 
+    const populationDataElements = dataElementsMetadata.dataElements.filter(
+        dataElement => dataElement.$type === "population"
+    );
+
+    const populationGroup = db.get("dataElementGroups", {
+        ...getOrThrow(sourceData.dataElementGroups, "population"),
+        dataElements: getIds(populationDataElements),
+    });
+
     return flattenPayloads([
         dataElementGroupsMetadata,
         dataElementsMetadata,
-        { dataElementGroups: [mainGroup] },
+        { dataElementGroups: [mainGroup, populationGroup] },
     ]);
 }
 


### PR DESCRIPTION
Required by https://github.com/EyeSeeTea/vaccination-app/issues/288

- Use AVERAGE_SUM_ORG_UNIT for population by age, we will post values for all periods.
- It's been necessary to add a dataElementGroup containing the population data elements. It will be used when getting data values, where you need to pass a dataSet (it will then check its data elements) or a dataElement group.

